### PR TITLE
Bugfix: User Non visible data was not used.

### DIFF
--- a/bankid/jsonclient.py
+++ b/bankid/jsonclient.py
@@ -169,7 +169,7 @@ class BankIDJSONClient(object):
         data['userVisibleData'] = self._encode_user_data(user_visible_data)
         if user_non_visible_data:
             data['userNonVisibleData'] = self._encode_user_data(
-                user_visible_data)
+                user_non_visible_data)
         if requirement and isinstance(requirement, dict):
             data['requirement'] = requirement
         # Handling potentially changed optional in-parameters.


### PR DESCRIPTION
When checking the XML that was the signature I was seeing the user visible data in both xml fields.
This bugfix should make sure that the non visible data is ending up in the signature response.