### PR TITLE
Add request timeout setting to clients

### DIFF
--- a/bankid/client.py
+++ b/bankid/client.py
@@ -48,7 +48,7 @@ class BankIDClient(object):
 
     """
 
-    def __init__(self, certificates, test_server=False, **kwargs):
+    def __init__(self, certificates, test_server=False, request_timeout=None, **kwargs):
         self.certs = certificates
 
         warnings.warn(
@@ -78,7 +78,8 @@ class BankIDClient(object):
         session.verify = self.verify_cert
         session.cert = self.certs
         session.headers = headers
-        transport = Transport(session=session)
+        timeout_kwarg = {} if request_timeout is None else {"timeout": request_timeout}
+        transport = Transport(session=session, **timeout_kwarg)
         self.client = Client(self.wsdl_url, transport=transport)
 
     def authenticate(self, personal_number, **kwargs):


### PR DESCRIPTION
Added a keyword argument `request_timeout` to each of the client classes. It's value defaults to `None`.
- The SOAP client passes the argument on to the `zeep` transport instance it uses unless the value is `None`; then it doesn't pass it on because `zeep` has a default timeout built-in that would otherwise be overridden.
- The private method `_post` is introduced on the JSON client. It should be used instead of using the post method on the `requests` session directly.
- The JSON client keeps the value of the timeout argument around for use by the `_post` method which passes it to the `requests` session instance.

Fixes #20