### PR TITLE
Update BankID developer docs URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ and signing orders and then collecting the results from the BankID servers.
 
 If you intend to use PyBankID in your project, you are advised to read
 the `BankID Relying Party Guidelines
-<https://www.bankid.com/bankid-i-dina-tjanster/rp-info>`_ before
+<https://www.bankid.com/utvecklare/rp-info>`_ before
 doing anything else. There, one can find information
 about how the BankID methods are defined and how to use them.
 
@@ -105,7 +105,7 @@ and a sign order is initiated in a similar fashion:
     }
 
 Since the `BankIDJSONClient` is using the BankID ``v5`` JSON API, the `personal_number` can now be omitted when calling
-`authenticate` and `sign`. See `BankID Relying Party Guidelines <https://www.bankid.com/bankid-i-dina-tjanster/rp-info>`_
+`authenticate` and `sign`. See `BankID Relying Party Guidelines <https://www.bankid.com/utvecklare/rp-info>`_
 for more information about this.
 
 The status of an order can then be studied by polling
@@ -149,7 +149,7 @@ with the ``collect`` method using the received ``orderRef``:
     }
 
 Please note that the ``collect`` method should be used sparingly: in the
-`BankID Relying Party Guidelines <https://www.bankid.com/bankid-i-dina-tjanster/rp-info>`_
+`BankID Relying Party Guidelines <https://www.bankid.com/utvecklare/rp-info>`_
 it states that *"collect should be called every two seconds and must not be
 called more frequent than once per second"*.
 

--- a/bankid/__init__.py
+++ b/bankid/__init__.py
@@ -13,7 +13,7 @@ and signing orders and then collecting the results from the BankID servers.
 
 If you intend to use PyBankID in your project, you are advised to read
 the `BankID Relying Party Guidelines
-<https://www.bankid.com/bankid-i-dina-tjanster/rp-info>`_ before
+<https://www.bankid.com/utvecklare/rp-info>`_ before
 doing anything else. There, one can find information
 about how the BankID methods are defined and how to use them.
 

--- a/docs/certutils.rst
+++ b/docs/certutils.rst
@@ -38,7 +38,7 @@ be obtained through PyBankID:
         certificates=cert_and_key, test_server=True)
 
 The test certificate is available on `BankID Technical Information webpage
-<https://www.bankid.com/bankid-i-dina-tjanster/rp-info>`_. The
+<https://www.bankid.com/utvecklare/rp-info>`_. The
 :py:func:`bankid.certutils.create_bankid_test_server_cert_and_key` in the
 :py:mod:`bankid.certutils` module fetches that test certificate, splits it
 into one certificate and one key part and converts it from

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ and signing orders and then collecting the results from the BankID servers.
 
 If you intend to use PyBankID in your project, you are advised to read
 the `BankID Relying Party Guidelines
-<https://www.bankid.com/bankid-i-dina-tjanster/rp-info>`_ before
+<https://www.bankid.com/utvecklare/rp-info>`_ before
 doing anything else. There, one can find information
 about how the BankID methods are defined and how to use them.
 

--- a/docs/jsonclient.rst
+++ b/docs/jsonclient.rst
@@ -46,7 +46,7 @@ and a sign order is initiated in a similar fashion:
     }
 
 Since the `BankIDJSONClient` is using the BankID ``v5`` JSON API, the `personal_number` can now be omitted when calling
-`authenticate` and `sign`. See `BankID Relying Party Guidelines <https://www.bankid.com/bankid-i-dina-tjanster/rp-info>`_
+`authenticate` and `sign`. See `BankID Relying Party Guidelines <https://www.bankid.com/utvecklare/rp-info>`_
 for more information about this.
 
 The status of an order can then be studied by polling
@@ -90,7 +90,7 @@ with the ``collect`` method using the received ``orderRef``:
     }
 
 Please note that the ``collect`` method should be used sparingly: in the
-`BankID Relying Party Guidelines <https://www.bankid.com/bankid-i-dina-tjanster/rp-info>`_
+`BankID Relying Party Guidelines <https://www.bankid.com/utvecklare/rp-info>`_
 it is specified that *"collect should be called every two seconds and must not be
 called more frequent than once per second"*.
 

--- a/docs/soapclient.rst
+++ b/docs/soapclient.rst
@@ -62,7 +62,7 @@ with the ``collect`` method using the received ``orderRef``:
                   'surname': 'Namnsson'}}
 
 Please note that the ``collect`` method should be used sparingly: in the
-`BankID Relying Party Guidelines <https://www.bankid.com/bankid-i-dina-tjanster/rp-info>`_.
+`BankID Relying Party Guidelines <https://www.bankid.com/utvecklare/rp-info>`_.
 it states that *"collect should be called every two seconds and must not be
 called more frequent than once per second"*.
 


### PR DESCRIPTION
The previous URL to BankID developer docs was broken. The updated one works as of 2020-06-05