### PR TITLE
Update requirements.txt in the demo app to the latest lib version

### DIFF
--- a/examples/qrdemo/requirements.txt
+++ b/examples/qrdemo/requirements.txt
@@ -1,3 +1,3 @@
 flask==2.0.2
-pybankid==0.12.0
+pybankid==0.13.1
 Flask-Caching==1.10.1


### PR DESCRIPTION
The demo app is currently broken as the certificate in 0.12 no longer works. This updates the dependency.