### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,9 +27,6 @@ jobs:
                 with:
                     python-version: ${{ matrix.python-version }}
                     
-            -   name: Upgrade pip. setuptools and wheel
-                run: python -m pip install --upgrade pip setuptools wheel
-
             -   name: Install dependencies
                 run: pip install -r requirements.txt
 
@@ -46,6 +43,9 @@ jobs:
             -   name: Test with pytest
                 run: |
                     pytest tests --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=bankid --cov-report=xml --cov-report=html
+
+            -   name: Upgrade pip. setuptools and wheel
+                run: python -m pip install --upgrade pip setuptools wheel
 
             -   name: Upload pytest test results
                 uses: actions/upload-artifact@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+                python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         steps:
             -   uses: actions/checkout@v3
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+                python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
         steps:
             -   uses: actions/checkout@v3
 

--- a/bankid/jsonclient.py
+++ b/bankid/jsonclient.py
@@ -11,7 +11,7 @@ import base64
 from urllib import parse as urlparse
 
 import requests
-import importlib.resources
+import importlib_resources
 
 from bankid.exceptions import get_json_error_class
 
@@ -23,8 +23,8 @@ def _encode_user_data(user_data):
         return base64.b64encode(user_data).decode("ascii")
 
 def _resolve_cert_path(file):
-    ref = importlib.resources.files("bankid.certs") / file
-    with importlib.resources.as_file(ref) as path:
+    ref = importlib_resources.files("bankid.certs") / file
+    with importlib_resources.as_file(ref) as path:
         return str(path)
 
 class BankIDJSONClient(object):

--- a/bankid/jsonclient.py
+++ b/bankid/jsonclient.py
@@ -11,7 +11,7 @@ import base64
 from urllib import parse as urlparse
 
 import requests
-from pkg_resources import resource_filename
+import importlib.resources
 
 from bankid.exceptions import get_json_error_class
 
@@ -22,6 +22,10 @@ def _encode_user_data(user_data):
     else:
         return base64.b64encode(user_data).decode("ascii")
 
+def _resolve_cert_path(file):
+    ref = importlib.resources.files("bankid.certs") / file
+    with importlib.resources.as_file(ref) as path:
+        return str(path)
 
 class BankIDJSONClient(object):
     """The client to use for communicating with BankID servers via the v.5 API.
@@ -42,10 +46,10 @@ class BankIDJSONClient(object):
 
         if test_server:
             self.api_url = "https://appapi2.test.bankid.com/rp/v5.1/"
-            self.verify_cert = resource_filename("bankid.certs", "appapi2.test.bankid.com.pem")
+            self.verify_cert = _resolve_cert_path("appapi2.test.bankid.com.pem")
         else:
             self.api_url = "https://appapi2.bankid.com/rp/v5.1/"
-            self.verify_cert = resource_filename("bankid.certs", "appapi2.bankid.com.pem")
+            self.verify_cert = _resolve_cert_path("appapi2.bankid.com.pem")
 
         self.client = requests.Session()
         self.client.verify = self.verify_cert

--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -37,7 +37,7 @@ Dependencies
 
 PyBankID makes use of the following external packages:
 * `requests>=2.20.0 <https://docs.python-requests.org/>`_
-* `six>=1.10.0 <https://pythonhosted.org/six/>`_
+* `importlib-resources==5.12.0 <https://importlib-resources.readthedocs.io/>`_
 
 
 Python 2, urllib3 and certificate verification

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests>=2.20.0
 importlib-resources==5.12.0
-
+requests>=2.20.0
+six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.20.0
+importlib-resources>=6.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 importlib-resources==5.12.0
 requests>=2.20.0
-six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.20.0
-importlib-resources>=6.1.1
+importlib-resources==5.12.0
+

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ import os
 import sys
 from shutil import rmtree
 
-from setuptools import find_packages, setup, Command
+from setuptools import Command, find_packages, setup
 
 # Package meta-data.
 NAME = "pybankid"
@@ -34,7 +34,7 @@ EMAIL = "henrik.blidh@nedomkull.com"
 AUTHOR = "Henrik Blidh"
 
 # What packages are required for this module to be executed?
-REQUIRED = ["requests", "six"]
+REQUIRED = open("requirements.txt").read().splitlines()
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Make package work with Python 3.7 - 3.12.

Added 3.12 as a testing target on Github Actions and moved setuptools to be installed after testing since it provides `pkg_resources` for Python 3.12. Majority of apps don't have setuptools at production runtime which means Python 3.12 won't be able to load `pkg_resources` since it's removed.

Switched to using `importlib` instead and added the official compat package for Python 3.7 and 3.8 lacking importlib.resources.files in CPython.