### PR TITLE
Expose QR code helper explicitly

### DIFF
--- a/bankid/__init__.py
+++ b/bankid/__init__.py
@@ -23,12 +23,14 @@ from bankid.__version__ import __version__, version
 from bankid.certutils import create_bankid_test_server_cert_and_key
 from bankid.syncclient import BankIDClient
 from bankid.asyncclient import BankIDAsyncClient
+from bankid.baseclient import generate_qr_code_content
 
 __all__ = [
     "BankIDClient",
     "BankIDAsyncClient",
     "exceptions",
     "create_bankid_test_server_cert_and_key",
+    "generate_qr_code_content",
     "__version__",
     "version",
 ]

--- a/bankid/baseclient.py
+++ b/bankid/baseclient.py
@@ -42,19 +42,8 @@ class BankIDClientBaseclass:
         self.client = None
 
     @staticmethod
-    def generate_qr_code_content(qr_start_token: str, start_t: [float, datetime], qr_start_secret: str):
-        """Given QR start token, time.time() or UTC datetime when initiated authentication call was made and the
-        QR start secret, calculate the current QR code content to display.
-        """
-        if isinstance(start_t, datetime):
-            start_t = start_t.timestamp()
-        elapsed_seconds_since_call = int(floor(time.time() - start_t))
-        qr_auth_code = hmac.new(
-            qr_start_secret.encode(),
-            msg=str(elapsed_seconds_since_call).encode(),
-            digestmod=hashlib.sha256,
-        ).hexdigest()
-        return f"bankid.{qr_start_token}.{elapsed_seconds_since_call}.{qr_auth_code}"
+    def generate_qr_code_content(qr_start_token: str, start_t: [float, datetime], qr_start_secret: str) -> str:
+        return generate_qr_code_content(qr_start_token, start_t, qr_start_secret)
 
     @staticmethod
     def _encode_user_data(user_data):
@@ -83,3 +72,18 @@ class BankIDClientBaseclass:
         if user_visible_data_format and user_visible_data_format == "simpleMarkdownV1":
             data["userVisibleDataFormat"] = "simpleMarkdownV1"
         return data
+
+
+def generate_qr_code_content(qr_start_token: str, start_t: [float, datetime], qr_start_secret: str) -> str:
+    """Given QR start token, time.time() or UTC datetime when initiated authentication call was made and the
+    QR start secret, calculate the current QR code content to display.
+    """
+    if isinstance(start_t, datetime):
+        start_t = start_t.timestamp()
+    elapsed_seconds_since_call = int(floor(time.time() - start_t))
+    qr_auth_code = hmac.new(
+        qr_start_secret.encode(),
+        msg=str(elapsed_seconds_since_call).encode(),
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+    return f"bankid.{qr_start_token}.{elapsed_seconds_since_call}.{qr_auth_code}"


### PR DESCRIPTION
At work, we recently migrated to v1.0.0 of pybankid. The way our code is written makes it cumbersome to access the `generate_qr_code_content` staticmethod of the client instance. These changes makes it possible to import that helper from the package top level, while keeping the staticmethod on the client class for backwards compatibility.