### PR TITLE
Use builtin importlib.resources.

### DIFF
--- a/bankid/certutils.py
+++ b/bankid/certutils.py
@@ -9,7 +9,8 @@ import os
 import subprocess
 from typing import Tuple
 
-import importlib_resources
+import pathlib
+import importlib.resources
 
 from bankid.certs import get_test_cert_p12
 from bankid.exceptions import BankIDError
@@ -17,10 +18,8 @@ from bankid.exceptions import BankIDError
 _TEST_CERT_PASSWORD = "qwerty123"
 
 
-def resolve_cert_path(file: str) -> str:
-    ref = importlib_resources.files("bankid.certs") / file
-    with importlib_resources.as_file(ref) as path:
-        return str(path)
+def resolve_cert_path(file: str) -> pathlib.Path:
+    return importlib.resources.files("bankid.certs").joinpath(file)
 
 
 def create_bankid_test_server_cert_and_key(destination_path: str) -> Tuple[str]:

--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -20,7 +20,6 @@ Dependencies
 PyBankID makes use of the following external packages:
 
 * `httpx <https://www.python-httpx.org/>`_
-* `importlib-resources >= 5.12.0 <https://importlib-resources.readthedocs.io/>`_
 
 Using the client
 ----------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 httpx
-importlib-resources>=5.12.0

--- a/tests/test_asyncclient.py
+++ b/tests/test_asyncclient.py
@@ -23,7 +23,7 @@ from bankid import BankIDAsyncClient, exceptions
 async def test_authentication_and_collect(cert_and_key, ip_address_async):
     """Authenticate call and then collect with the returned orderRef UUID."""
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
-    assert "appapi2.test.bankid.com.pem" in c.verify_cert
+    assert "appapi2.test.bankid.com.pem" in str(c.verify_cert)
     out = await c.authenticate(ip_address_async)
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.

--- a/tests/test_syncclient.py
+++ b/tests/test_syncclient.py
@@ -29,7 +29,7 @@ def test_authentication_and_collect(cert_and_key, ip_address, random_personal_nu
     """Authenticate call and then collect with the returned orderRef UUID."""
 
     c = BankIDClient(certificates=cert_and_key, test_server=True)
-    assert "appapi2.test.bankid.com.pem" in c.verify_cert
+    assert "appapi2.test.bankid.com.pem" in str(c.verify_cert)
     out = c.authenticate(ip_address, random_personal_number)
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
@@ -139,4 +139,4 @@ def test_cancel_with_invalid_uuid(cert_and_key):
 def test_correct_prod_server_urls(cert_and_key, test_server, endpoint):
     c = BankIDClient(certificates=cert_and_key, test_server=test_server)
     assert c.api_url == "https://{0}/rp/v6.0/".format(endpoint)
-    assert "{0}.pem".format(endpoint) in c.verify_cert
+    assert "{0}.pem".format(endpoint) in str(c.verify_cert)


### PR DESCRIPTION
Supporting Python >=3.9 does not require using the backport.

Also, use joinpath() to simplify the retrival of the path+return pathlib.Path instead of str.