### PR TITLE
Add mypy for type checking

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,6 +40,9 @@ jobs:
                     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
                     flake8 ./bankid --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+            -   name: Look for type errors
+                run: mypy
+
             -   name: Test with pytest
                 run: |
                     pytest tests --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=bankid --cov-report=xml --cov-report=html

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ docs/_build/
 # PyBuilder
 target/
 
+# mypy
+.mypy_cache
 
 ### Vagrant template
 .vagrant/
@@ -125,5 +127,3 @@ atlassian-ide-plugin.xml
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# PyBankID
+
+Pull requests are welcome! They should target the [develop](https://github.com/hbldh/pybankid/tree/develop) branch.
+
+## Development
+
+Dependencies needed for development can be installed through pip:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+## Testing
+
+The PyBankID solution can be tested with [pytest](https://pytest.org/):
+
+```bash
+pytest
+```
+
+## Type checking
+
+PyBankID is annotated with types and [mypy](https://www.mypy-lang.org/) is used as type-checker. All contributions should include type annotations.
+
+```bash
+mypy
+```

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ PyBankID provides both a synchronous and an asynchronous client for communicatio
 ```python
 from bankid import BankIDClient
 client = BankIDClient(certificates=(
-    'path/to/certificate.pem', 
-    'path/to/key.pem', 
+    'path/to/certificate.pem',
+    'path/to/key.pem',
 ))
 ```
 
@@ -125,12 +125,12 @@ client.collect(order_ref="a9b791c3-459f-492b-bf61-23027876140b")
 }
 ```
 
-Please note that the `collect` method should be used sparingly: in the [BankID Integration Guide](https://www.bankid.com/en/utvecklare/guider/teknisk-integrationsguide) it is specified that *"collect should be called every two seconds and must not be called more frequent than once per second"*.
+Please note that the `collect` method should be used sparingly: in the [BankID Integration Guide](https://www.bankid.com/en/utvecklare/guider/teknisk-integrationsguide) it is specified that _"collect should be called every two seconds and must not be called more frequent than once per second"_.
 
 PyBankID also implements the `phone/auth` and `phone/sign` methods, for performing authentication and signing with
 users that are contacted through phone. For documentation on this, see [PyBankID's Read the Docs page](https://pybankid.readthedocs.io/en/latest/).
 
-### Asynchronous client 
+### Asynchronous client
 
 The asynchronous client is used in the same way as the synchronous client, with the difference that all request are performed asynchronously.
 
@@ -181,12 +181,4 @@ print(cert_and_key)
 ['/home/hbldh/certificate.pem', '/home/hbldh/key.pem']
 client = bankid.BankIDClient(
     certificates=cert_and_key, test_server=True)
-```
-
-## Testing
-
-The PyBankID solution can be tested with [pytest](https://pytest.org/):
-
-```bash
-pytest tests/
 ```

--- a/bankid/asyncclient.py
+++ b/bankid/asyncclient.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Dict, Any
+from typing import Any, Dict, Tuple, Union
 
 import httpx
 
@@ -6,7 +6,7 @@ from bankid.baseclient import BankIDClientBaseclass
 from bankid.exceptions import get_json_error_class
 
 
-class BankIDAsyncClient(BankIDClientBaseclass):
+class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
     """The asynchronous client to use for communicating with BankID servers via the v6 API.
 
     :param certificates: Tuple of string paths to the certificate to use and
@@ -19,25 +19,19 @@ class BankIDAsyncClient(BankIDClientBaseclass):
 
     """
 
-    def __init__(self, certificates: Tuple[str, str], test_server: bool = False, request_timeout: Optional[int] = None):
+    def __init__(self, certificates: Tuple[str, str], test_server: bool = False, request_timeout: int = 5):
         super().__init__(certificates, test_server, request_timeout)
 
-        kwargs = {
-            "cert": self.certs,
-            "headers": {"Content-Type": "application/json"},
-            "verify": self.verify_cert,
-        }
-        if request_timeout:
-            kwargs["timeout"] = request_timeout
-        self.client = httpx.AsyncClient(**kwargs)
+        headers = {"Content-Type": "application/json"}
+        self.client = httpx.AsyncClient(cert=self.certs, headers=headers, verify=str(self.verify_cert), timeout=request_timeout)
 
     async def authenticate(
         self,
         end_user_ip: str,
-        requirement: Dict[str, Any] = None,
-        user_visible_data: str = None,
-        user_non_visible_data: str = None,
-        user_visible_data_format: str = None,
+        requirement: Union[Dict[str, Any], None] = None,
+        user_visible_data: Union[str, None]  = None,
+        user_non_visible_data: Union[str, None]  = None,
+        user_visible_data_format: Union[str, None]  = None,
     ) -> Dict[str, str]:
         """Request an authentication order. The :py:meth:`collect` method
         is used to query the status of the order.
@@ -85,7 +79,7 @@ class BankIDAsyncClient(BankIDClientBaseclass):
         response = await self.client.post(self._auth_endpoint, json=data)
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
@@ -93,10 +87,10 @@ class BankIDAsyncClient(BankIDClientBaseclass):
         self,
         personal_number: str,
         call_initiator: str,
-        requirement: Dict[str, Any] = None,
-        user_visible_data: str = None,
-        user_non_visible_data: str = None,
-        user_visible_data_format: str = None,
+        requirement: Union[Dict[str, Any], None] = None,
+        user_visible_data: Union[str, None] = None,
+        user_non_visible_data: Union[str, None] = None,
+        user_visible_data_format: Union[str, None] = None,
     ) -> Dict[str, str]:
         """Initiates an authentication order when the user is talking
         to the RP over the phone. The :py:meth:`collect` method
@@ -150,17 +144,17 @@ class BankIDAsyncClient(BankIDClientBaseclass):
         response = await self.client.post(self._phone_auth_endpoint, json=data)
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
     async def sign(
         self,
-        end_user_ip,
+        end_user_ip: str,
         user_visible_data: str,
-        requirement: Dict[str, Any] = None,
-        user_non_visible_data: str = None,
-        user_visible_data_format: str = None,
+        requirement: Union[Dict[str, Any], None] = None,
+        user_non_visible_data: Union[str, None] = None,
+        user_visible_data_format: Union[str, None] = None,
     ) -> Dict[str, str]:
         """Request a signing order. The :py:meth:`collect` method
         is used to query the status of the order.
@@ -206,7 +200,7 @@ class BankIDAsyncClient(BankIDClientBaseclass):
         response = await self.client.post(self._sign_endpoint, json=data)
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
@@ -215,9 +209,9 @@ class BankIDAsyncClient(BankIDClientBaseclass):
         personal_number: str,
         call_initiator: str,
         user_visible_data: str,
-        requirement: Dict[str, Any] = None,
-        user_non_visible_data: str = None,
-        user_visible_data_format: str = None,
+        requirement: Union[Dict[str, Any], None] = None,
+        user_non_visible_data: Union[str, None] = None,
+        user_visible_data_format: Union[str, None] = None,
     ) -> Dict[str, str]:
         """Initiates an authentication order when the user is talking to
         the RP over the phone. The :py:meth:`collect` method
@@ -269,7 +263,7 @@ class BankIDAsyncClient(BankIDClientBaseclass):
         response = await self.client.post(self._phone_sign_endpoint, json=data)
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
@@ -341,7 +335,7 @@ class BankIDAsyncClient(BankIDClientBaseclass):
         response = await self.client.post(self._collect_endpoint, json={"orderRef": order_ref})
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
@@ -362,6 +356,6 @@ class BankIDAsyncClient(BankIDClientBaseclass):
         response = await self.client.post(self._cancel_endpoint, json={"orderRef": order_ref})
 
         if response.status_code == 200:
-            return response.json() == {}
+            return response.json() == {}  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)

--- a/bankid/certs/__init__.py
+++ b/bankid/certs/__init__.py
@@ -2,13 +2,14 @@
 # We have to pin these to prevent basic MITM attacks.
 
 from pathlib import Path
+from typing import Tuple
 
 
-def get_test_cert_p12():
+def get_test_cert_p12() -> Path:
     return (Path(__file__).parent / "FPTestcert4_20230629.p12").resolve()
 
 
-def get_test_cert_and_key():
+def get_test_cert_and_key() -> Tuple[Path, Path]:
     return (
         (Path(__file__).parent / "FPTestcert4_20230629_cert.pem").resolve(),
         (Path(__file__).parent / "FPTestcert4_20230629_key.pem").resolve(),

--- a/bankid/exceptions.py
+++ b/bankid/exceptions.py
@@ -1,7 +1,9 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+import httpx
+from typing import Any, Dict, Union
 
 
-def get_json_error_class(response):
+def get_json_error_class(response: httpx.Response) -> BankIDError:
     data = response.json()
     error_class = _JSON_ERROR_CODE_TO_CLASS.get(data.get("errorCode"), BankIDError)
     return error_class("{0}: {1}".format(data.get("errorCode"), data.get("details")), raw_data=data)
@@ -10,10 +12,10 @@ def get_json_error_class(response):
 class BankIDError(Exception):
     """Parent exception class for all PyBankID errors."""
 
-    def __init__(self, *args, **kwargs):
-        super(BankIDError, self).__init__(*args)
-        self.rfa = None
-        self.json = kwargs.get("raw_data", {})
+    def __init__(self, *args: Any, raw_data: Union[Dict[str, Any], None] = None, **kwargs: Any) -> None:
+        super(BankIDError, self).__init__(*args, **kwargs)
+        self.rfa: Union[int, None] = None
+        self.json = raw_data or {}
 
 
 class BankIDWarning(Warning):
@@ -35,7 +37,7 @@ class InvalidParametersError(BankIDError):
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -53,7 +55,7 @@ class AlreadyInProgressError(BankIDError):
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.rfa = 4
 
@@ -71,7 +73,7 @@ class InternalError(BankIDError):
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.rfa = 5
 
@@ -87,7 +89,7 @@ class MaintenanceError(BankIDError):
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.rfa = 5
 
@@ -103,7 +105,7 @@ class UnauthorizedError(BankIDError):
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -118,7 +120,7 @@ class NotFoundError(BankIDError):
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
 
@@ -133,12 +135,12 @@ class RequestTimeoutError(BankIDError):
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.rfa = 5
 
 
-_JSON_ERROR_CODE_TO_CLASS = {
+_JSON_ERROR_CODE_TO_CLASS: Dict[str, type[BankIDError]] = {
     "invalidParameters": InvalidParametersError,
     "alreadyInProgress": AlreadyInProgressError,
     "unauthorized": UnauthorizedError,

--- a/bankid/experimental/helper.py
+++ b/bankid/experimental/helper.py
@@ -26,10 +26,6 @@ class BankIdSignatureContainer:
         self.raw = signature
 
     @property
-    def signature_value(self):
-        return B64Value(self.root[1].text).decode
-
-    @property
     def signed_data_digest(self):
         return self.root[0][2][2]
 

--- a/bankid/qr.py
+++ b/bankid/qr.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import hashlib
 import hmac
 import time
@@ -5,7 +7,7 @@ from datetime import datetime
 from math import floor
 
 
-def generate_qr_code_content(qr_start_token: str, start_t: [float, datetime], qr_start_secret: str) -> str:
+def generate_qr_code_content(qr_start_token: str, start_t: Union[float, datetime], qr_start_secret: str) -> str:
     """Given QR start token, time.time() or UTC datetime when initiated authentication call was made and the
     QR start secret, calculate the current QR code content to display.
     """

--- a/bankid/syncclient.py
+++ b/bankid/syncclient.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Dict, Any
+from typing import Any, Dict, Tuple, Union
 
 import httpx
 
@@ -6,7 +6,7 @@ from bankid.baseclient import BankIDClientBaseclass
 from bankid.exceptions import get_json_error_class
 
 
-class BankIDClient(BankIDClientBaseclass):
+class BankIDClient(BankIDClientBaseclass[httpx.Client]):
     """The synchronous client to use for communicating with BankID servers via the v6 API.
 
     :param certificates: Tuple of string paths to the certificate to use and
@@ -19,25 +19,19 @@ class BankIDClient(BankIDClientBaseclass):
 
     """
 
-    def __init__(self, certificates: Tuple[str, str], test_server: bool = False, request_timeout: Optional[int] = None):
+    def __init__(self, certificates: Tuple[str, str], test_server: bool = False, request_timeout: int = 5):
         super().__init__(certificates, test_server, request_timeout)
 
-        kwargs = {
-            "cert": self.certs,
-            "headers": {"Content-Type": "application/json"},
-            "verify": self.verify_cert,
-        }
-        if request_timeout:
-            kwargs["timeout"] = request_timeout
-        self.client = httpx.Client(**kwargs)
+        headers= {"Content-Type": "application/json"}
+        self.client = httpx.Client(cert=self.certs, headers=headers, verify=str(self.verify_cert), timeout=request_timeout)
 
     def authenticate(
         self,
         end_user_ip: str,
-        requirement: Dict[str, Any] = None,
-        user_visible_data: str = None,
-        user_non_visible_data: str = None,
-        user_visible_data_format: str = None,
+        requirement: Union[Dict[str, Any], None] = None,
+        user_visible_data: Union[str, None] = None,
+        user_non_visible_data: Union[str, None] = None,
+        user_visible_data_format: Union[str, None] = None,
     ) -> Dict[str, str]:
         """Request an authentication order. The :py:meth:`collect` method
         is used to query the status of the order.
@@ -85,7 +79,7 @@ class BankIDClient(BankIDClientBaseclass):
         response = self.client.post(self._auth_endpoint, json=data)
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
@@ -93,10 +87,10 @@ class BankIDClient(BankIDClientBaseclass):
         self,
         personal_number: str,
         call_initiator: str,
-        requirement: Dict[str, Any] = None,
-        user_visible_data: str = None,
-        user_non_visible_data: str = None,
-        user_visible_data_format: str = None,
+        requirement: Union[Dict[str, Any], None] = None,
+        user_visible_data: Union[str, None] = None,
+        user_non_visible_data: Union[str, None] = None,
+        user_visible_data_format: Union[str, None] = None,
     ) -> Dict[str, str]:
         """Initiates an authentication order when the user is talking
         to the RP over the phone. The :py:meth:`collect` method
@@ -150,7 +144,7 @@ class BankIDClient(BankIDClientBaseclass):
         response = self.client.post(self._phone_auth_endpoint, json=data)
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
@@ -158,9 +152,9 @@ class BankIDClient(BankIDClientBaseclass):
         self,
         end_user_ip: str,
         user_visible_data: str,
-        requirement: Dict[str, Any] = None,
-        user_non_visible_data: str = None,
-        user_visible_data_format: str = None,
+        requirement: Union[Dict[str, Any], None] = None,
+        user_non_visible_data: Union[str, None] = None,
+        user_visible_data_format: Union[str, None] = None,
     ) -> Dict[str, str]:
         """Request a signing order. The :py:meth:`collect` method
         is used to query the status of the order.
@@ -205,7 +199,7 @@ class BankIDClient(BankIDClientBaseclass):
         response = self.client.post(self._sign_endpoint, json=data)
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
@@ -214,9 +208,9 @@ class BankIDClient(BankIDClientBaseclass):
         personal_number: str,
         call_initiator: str,
         user_visible_data: str,
-        requirement: Dict[str, Any] = None,
-        user_non_visible_data: str = None,
-        user_visible_data_format: str = None,
+        requirement: Union[Dict[str, Any], None] = None,
+        user_non_visible_data: Union[str, None] = None,
+        user_visible_data_format: Union[str, None] = None,
     ) -> Dict[str, str]:
         """Initiates an authentication order when the user is talking to
         the RP over the phone.  The :py:meth:`collect` method
@@ -268,7 +262,7 @@ class BankIDClient(BankIDClientBaseclass):
         response = self.client.post(self._phone_sign_endpoint, json=data)
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
@@ -340,7 +334,7 @@ class BankIDClient(BankIDClientBaseclass):
         response = self.client.post(self._collect_endpoint, json={"orderRef": order_ref})
 
         if response.status_code == 200:
-            return response.json()
+            return response.json()  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)
 
@@ -361,6 +355,6 @@ class BankIDClient(BankIDClientBaseclass):
         response = self.client.post(self._cancel_endpoint, json={"orderRef": order_ref})
 
         if response.status_code == 200:
-            return response.json() == {}
+            return response.json() == {}  # type: ignore[no-any-return]
         else:
             raise get_json_error_class(response)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+files = bankid,tests
+exclude = bankid/experimental
+show_error_codes = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+disallow_untyped_calls = true
+enable_error_code = truthy-bool
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+strict_equality = true
+warn_unreachable = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,9 @@ pytest-cov
 sphinx
 sphinx-rtd-theme
 mypy
+types-docutils
+types-mock
+types-Pygments
+types-pyOpenSSL
+types-pytz
+types-setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-asyncio
 pytest-cov
 sphinx
 sphinx-rtd-theme
+mypy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import random
 
 import pytest
+from typing import List, Tuple
 
 from bankid.certs import get_test_cert_and_key
 
@@ -11,16 +12,16 @@ def ip_address() -> str:
 
 
 @pytest.fixture()
-def cert_and_key():
+def cert_and_key() -> Tuple[str, str]:
     cert, key = get_test_cert_and_key()
     return str(cert), str(key)
 
 
 @pytest.fixture()
-def random_personal_number():
+def random_personal_number() -> str:
     """Simple random Swedish personal number generator."""
 
-    def _luhn_digit(id_):
+    def _luhn_digit(id_: str) -> int:
         """Calculate Luhn control digit for personal number.
 
         Code adapted from `Faker
@@ -34,11 +35,10 @@ def random_personal_number():
 
         """
 
-        def digits_of(n):
+        def digits_of(n: int) -> List[int]:
             return [int(i) for i in str(n)]
 
-        id_ = int(id_) * 10
-        digits = digits_of(id_)
+        digits = digits_of(int(id_) * 10)
         checksum = sum(digits[-1::-2])
         for k in digits[-2::-2]:
             checksum += sum(digits_of(k * 2))

--- a/tests/test_asyncclient.py
+++ b/tests/test_asyncclient.py
@@ -15,12 +15,13 @@ Created on 2023-12-15
 import uuid
 
 import pytest
+from typing import Tuple
 
 from bankid import BankIDAsyncClient, exceptions
 
 
 @pytest.mark.asyncio
-async def test_authentication_and_collect(cert_and_key, ip_address):
+async def test_authentication_and_collect(cert_and_key: Tuple[str, str], ip_address: str) -> None:
     """Authenticate call and then collect with the returned orderRef UUID."""
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
     assert "appapi2.test.bankid.com.pem" in str(c.verify_cert)
@@ -28,14 +29,14 @@ async def test_authentication_and_collect(cert_and_key, ip_address):
 
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = await c.collect(out.get("orderRef"))
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = await c.collect(str(order_ref))
     assert collect_status.get("status") == "pending"
     assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
 
 
 @pytest.mark.asyncio
-async def test_sign_and_collect(cert_and_key, ip_address):
+async def test_sign_and_collect(cert_and_key: Tuple[str, str], ip_address: str) -> None:
     """Sign call and then collect with the returned orderRef UUID."""
 
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
@@ -46,35 +47,35 @@ async def test_sign_and_collect(cert_and_key, ip_address):
     )
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = await c.collect(out.get("orderRef"))
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = await c.collect(str(order_ref))
     assert collect_status.get("status") == "pending"
     assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
 
 
 @pytest.mark.asyncio
-async def test_phone_sign_and_collect(cert_and_key, random_personal_number):
+async def test_phone_sign_and_collect(cert_and_key: Tuple[str, str], random_personal_number: str) -> None:
     """Phone sign call and then collect with the returned orderRef UUID."""
 
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
     out = await c.phone_sign(random_personal_number, "RP", user_visible_data="The data to be signed")
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    order_ref = uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = await c.collect(out.get("orderRef"))
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = await c.collect(str(order_ref))
     assert collect_status.get("status") == "pending"
     assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
 
 
 @pytest.mark.asyncio
-async def test_invalid_orderref_raises_error(cert_and_key):
+async def test_invalid_orderref_raises_error(cert_and_key: Tuple[str, str]) -> None:
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
     with pytest.raises(exceptions.InvalidParametersError):
         await c.collect("invalid-uuid")
 
 
 @pytest.mark.asyncio
-async def test_already_in_progress_raises_error(cert_and_key, ip_address, random_personal_number):
+async def test_already_in_progress_raises_error(cert_and_key: Tuple[str, str], ip_address: str, random_personal_number: str) -> None:
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
     await c.authenticate(ip_address, requirement={"personalNumber": random_personal_number})
     with pytest.raises(exceptions.AlreadyInProgressError):
@@ -82,7 +83,7 @@ async def test_already_in_progress_raises_error(cert_and_key, ip_address, random
 
 
 @pytest.mark.asyncio
-async def test_already_in_progress_raises_error_2(cert_and_key, ip_address, random_personal_number):
+async def test_already_in_progress_raises_error_2(cert_and_key: Tuple[str, str], ip_address: str, random_personal_number: str) -> None:
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
     await c.sign(
         ip_address,
@@ -96,42 +97,42 @@ async def test_already_in_progress_raises_error_2(cert_and_key, ip_address, rand
 
 
 @pytest.mark.asyncio
-async def test_authentication_and_cancel(cert_and_key, ip_address):
+async def test_authentication_and_cancel(cert_and_key: Tuple[str, str], ip_address: str) -> None:
     """Authenticate call and then cancel it"""
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
     out = await c.authenticate(ip_address)
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    order_ref = uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = await c.collect(out.get("orderRef"))
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = await c.collect(str(order_ref))
     assert collect_status.get("status") == "pending"
     assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
     success = await c.cancel(str(order_ref))
     assert success
     with pytest.raises(exceptions.InvalidParametersError):
-        collect_status = await c.collect(out.get("orderRef"))
+        collect_status = await c.collect(str(order_ref))
 
 
 @pytest.mark.asyncio
-async def test_phone_authentication_and_cancel(cert_and_key, random_personal_number):
+async def test_phone_authentication_and_cancel(cert_and_key: Tuple[str, str], random_personal_number: str) -> None:
     """Phone authenticate call and then cancel it"""
 
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
     out = await c.phone_authenticate(random_personal_number, "user")
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    order_ref = uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = await c.collect(out.get("orderRef"))
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = await c.collect(str(order_ref))
     assert collect_status.get("status") == "pending"
     assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
     success = await c.cancel(str(order_ref))
     assert success
     with pytest.raises(exceptions.InvalidParametersError):
-        collect_status = await c.collect(out.get("orderRef"))
+        collect_status = await c.collect(str(order_ref))
 
 
 @pytest.mark.asyncio
-async def test_cancel_with_invalid_uuid(cert_and_key):
+async def test_cancel_with_invalid_uuid(cert_and_key: Tuple[str, str]) -> None:
     c = BankIDAsyncClient(certificates=cert_and_key, test_server=True)
     invalid_order_ref = uuid.uuid4()
     with pytest.raises(exceptions.InvalidParametersError):

--- a/tests/test_certutils.py
+++ b/tests/test_certutils.py
@@ -5,7 +5,7 @@ from pytest import TempdirFactory
 import bankid
 
 
-def test_create_bankid_test_server_cert_and_key(tmpdir_factory: TempdirFactory):
+def test_create_bankid_test_server_cert_and_key(tmpdir_factory: TempdirFactory) -> None:
     paths = bankid.certutils.create_bankid_test_server_cert_and_key(tmpdir_factory.mktemp("certs"))
     assert os.path.exists(paths[0])
     assert os.path.exists(paths[1])

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import Union
 
 import pytest
 
@@ -18,10 +19,10 @@ import bankid
         (bankid.exceptions.BankIDError, None),
     ],
 )
-def test_exceptions(exception_class, rfa):
+def test_exceptions(exception_class: type[Exception], rfa: Union[int, None]) -> None:
     e = exception_class()
-    assert e.rfa == rfa
     assert isinstance(e, bankid.exceptions.BankIDError)
+    assert e.rfa == rfa
 
 
 @pytest.mark.parametrize(
@@ -37,8 +38,9 @@ def test_exceptions(exception_class, rfa):
         (bankid.exceptions.BankIDError, "Unknown error code"),
     ],
 )
-def test_error_class_factory(exception_class, error_code):
+def test_error_class_factory(exception_class: type[Exception], error_code: str) -> None:
     MockResponse = namedtuple("MockResponse", ["json"])
     response = MockResponse(json=lambda: {"errorCode": error_code})
-    e_class = bankid.exceptions.get_json_error_class(response)
+    # error: Argument 1 to "get_json_error_class" has incompatible type "MockResponse@41"; expected "Response"  [arg-type]
+    e_class = bankid.exceptions.get_json_error_class(response)  # type: ignore[arg-type]
     assert isinstance(e_class, exception_class)

--- a/tests/test_syncclient.py
+++ b/tests/test_syncclient.py
@@ -16,30 +16,31 @@ Created on 2024-01-18
 import uuid
 
 import pytest
+from typing import Tuple
 
 try:
     from unittest import mock
 except:
-    import mock
+    import mock  # type: ignore[no-redef]
 
 from bankid import BankIDClient, exceptions
 
 
-def test_authentication_and_collect(cert_and_key, ip_address, random_personal_number):
+def test_authentication_and_collect(cert_and_key: Tuple[str, str], ip_address: str, random_personal_number: str) -> None:
     """Authenticate call and then collect with the returned orderRef UUID."""
 
     c = BankIDClient(certificates=cert_and_key, test_server=True)
     assert "appapi2.test.bankid.com.pem" in str(c.verify_cert)
-    out = c.authenticate(ip_address, random_personal_number)
+    out = c.authenticate(ip_address, requirement={"personalNumber": random_personal_number})
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    order_ref = uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = c.collect(out.get("orderRef"))
-    assert collect_status.get("status") == "pending"
-    assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = c.collect(str(order_ref))
+    assert collect_status["status"] == "pending"
+    assert collect_status["hintCode"] in ("outstandingTransaction", "noClient")
 
 
-def test_sign_and_collect(cert_and_key, ip_address):
+def test_sign_and_collect(cert_and_key: Tuple[str, str], ip_address: str) -> None:
     """Sign call and then collect with the returned orderRef UUID."""
 
     c = BankIDClient(certificates=cert_and_key, test_server=True)
@@ -50,39 +51,39 @@ def test_sign_and_collect(cert_and_key, ip_address):
     )
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    order_ref = uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = c.collect(out.get("orderRef"))
-    assert collect_status.get("status") == "pending"
-    assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = c.collect(str(order_ref))
+    assert collect_status["status"] == "pending"
+    assert collect_status["hintCode"] in ("outstandingTransaction", "noClient")
 
 
-def test_phone_sign_and_collect(cert_and_key, random_personal_number):
+def test_phone_sign_and_collect(cert_and_key: Tuple[str, str], random_personal_number: str) -> None:
     """Phone sign call and then collect with the returned orderRef UUID."""
 
     c = BankIDClient(certificates=cert_and_key, test_server=True)
     out = c.phone_sign(random_personal_number, "user", user_visible_data="The data to be signed")
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    order_ref = uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = c.collect(out.get("orderRef"))
-    assert collect_status.get("status") == "pending"
-    assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = c.collect(str(order_ref))
+    assert collect_status["status"] == "pending"
+    assert collect_status["hintCode"] in ("outstandingTransaction", "noClient")
 
 
-def test_invalid_orderref_raises_error(cert_and_key):
+def test_invalid_orderref_raises_error(cert_and_key: Tuple[str, str]) -> None:
     c = BankIDClient(certificates=cert_and_key, test_server=True)
     with pytest.raises(exceptions.InvalidParametersError):
         collect_status = c.collect("invalid-uuid")
 
 
-def test_already_in_progress_raises_error(cert_and_key, ip_address, random_personal_number):
+def test_already_in_progress_raises_error(cert_and_key: Tuple[str, str], ip_address: str, random_personal_number: str) -> None:
     c = BankIDClient(certificates=cert_and_key, test_server=True)
     out = c.authenticate(ip_address, requirement={"personalNumber": random_personal_number})
     with pytest.raises(exceptions.AlreadyInProgressError):
         out2 = c.authenticate(ip_address, requirement={"personalNumber": random_personal_number})
 
 
-def test_already_in_progress_raises_error_2(cert_and_key, ip_address, random_personal_number):
+def test_already_in_progress_raises_error_2(cert_and_key: Tuple[str, str], ip_address: str, random_personal_number: str) -> None:
     c = BankIDClient(certificates=cert_and_key, test_server=True)
     out = c.sign(ip_address, requirement={"personalNumber": random_personal_number}, user_visible_data="Text to sign")
     with pytest.raises(exceptions.AlreadyInProgressError):
@@ -91,41 +92,41 @@ def test_already_in_progress_raises_error_2(cert_and_key, ip_address, random_per
         )
 
 
-def test_authentication_and_cancel(cert_and_key, ip_address, random_personal_number):
+def test_authentication_and_cancel(cert_and_key: Tuple[str, str], ip_address: str, random_personal_number: str) -> None:
     """Authenticate call and then cancel it"""
 
     c = BankIDClient(certificates=cert_and_key, test_server=True)
     out = c.authenticate(ip_address, requirement={"personalNumber": random_personal_number})
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    order_ref = uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = c.collect(out.get("orderRef"))
-    assert collect_status.get("status") == "pending"
-    assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = c.collect(str(order_ref))
+    assert collect_status["status"] == "pending"
+    assert collect_status["hintCode"] in ("outstandingTransaction", "noClient")
     success = c.cancel(str(order_ref))
     assert success
     with pytest.raises(exceptions.InvalidParametersError):
-        collect_status = c.collect(out.get("orderRef"))
+        collect_status = c.collect(str(order_ref))
 
 
-def test_phone_authentication_and_cancel(cert_and_key, random_personal_number):
+def test_phone_authentication_and_cancel(cert_and_key: Tuple[str, str], random_personal_number: str) -> None:
     """Phone authenticate call and then cancel it"""
 
     c = BankIDClient(certificates=cert_and_key, test_server=True)
     out = c.phone_authenticate(random_personal_number, "user")
     assert isinstance(out, dict)
     # UUID.__init__ performs the UUID compliance assertion.
-    order_ref = uuid.UUID(out.get("orderRef"), version=4)
-    collect_status = c.collect(out.get("orderRef"))
-    assert collect_status.get("status") == "pending"
-    assert collect_status.get("hintCode") in ("outstandingTransaction", "noClient")
+    order_ref = uuid.UUID(out["orderRef"], version=4)
+    collect_status = c.collect(str(order_ref))
+    assert collect_status["status"] == "pending"
+    assert collect_status["hintCode"] in ("outstandingTransaction", "noClient")
     success = c.cancel(str(order_ref))
     assert success
     with pytest.raises(exceptions.InvalidParametersError):
-        collect_status = c.collect(out.get("orderRef"))
+        collect_status = c.collect(str(order_ref))
 
 
-def test_cancel_with_invalid_uuid(cert_and_key):
+def test_cancel_with_invalid_uuid(cert_and_key: Tuple[str, str]) -> None:
     c = BankIDClient(certificates=cert_and_key, test_server=True)
     invalid_order_ref = uuid.uuid4()
     with pytest.raises(exceptions.InvalidParametersError):
@@ -136,7 +137,7 @@ def test_cancel_with_invalid_uuid(cert_and_key):
     "test_server, endpoint",
     [(False, "appapi2.bankid.com"), (True, "appapi2.test.bankid.com")],
 )
-def test_correct_prod_server_urls(cert_and_key, test_server, endpoint):
+def test_correct_prod_server_urls(cert_and_key: Tuple[str, str], test_server: bool, endpoint: str) -> None:
     c = BankIDClient(certificates=cert_and_key, test_server=test_server)
     assert c.api_url == "https://{0}/rp/v6.0/".format(endpoint)
     assert "{0}.pem".format(endpoint) in str(c.verify_cert)


### PR DESCRIPTION
There are some type annotations already but there are some errors here and there. Since I think type annotations are very nice and helps a lot in both developing and using a library, I think the time has come to also use mypy for type checking.

The final goal here is to also type the json/dicts returned from the BankID API using `typing.TypedDict` but that's another story.

I intentionally didn't add type annotations to bankid/experimental since it's...experimental anyway 😸 