### PR TITLE
Add type annotations for BankID API responses

### DIFF
--- a/bankid/asyncclient.py
+++ b/bankid/asyncclient.py
@@ -4,6 +4,15 @@ import httpx
 
 from bankid.baseclient import BankIDClientBaseclass
 from bankid.exceptions import get_json_error_class
+from bankid.responses import (
+    AuthenticateResponse,
+    CollectCompleteResponse,
+    CollectFailedResponse,
+    CollectPendingResponse,
+    PhoneAuthenticateResponse,
+    PhoneSignResponse,
+    SignResponse,
+)
 
 
 class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
@@ -32,7 +41,7 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
         user_visible_data: Union[str, None]  = None,
         user_non_visible_data: Union[str, None]  = None,
         user_visible_data_format: Union[str, None]  = None,
-    ) -> Dict[str, str]:
+    ) -> AuthenticateResponse:
         """Request an authentication order. The :py:meth:`collect` method
         is used to query the status of the order.
 
@@ -62,8 +71,8 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
             this parameter indicates that userVisibleData holds formatting characters which
             potentially make for a more pleasant user experience.
         :type user_visible_data_format: str
-        :return: The order response.
-        :rtype: dict
+        :return: The order response parsed as a dict.
+        :rtype: AuthenticateResponse
         :raises BankIDError: raises a subclass of this error
                              when error has been returned from server.
 
@@ -91,7 +100,7 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
         user_visible_data: Union[str, None] = None,
         user_non_visible_data: Union[str, None] = None,
         user_visible_data_format: Union[str, None] = None,
-    ) -> Dict[str, str]:
+    ) -> PhoneAuthenticateResponse:
         """Initiates an authentication order when the user is talking
         to the RP over the phone. The :py:meth:`collect` method
         is used to query the status of the order.
@@ -123,8 +132,8 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
             this parameter indicates that userVisibleData holds formatting characters which
             potentially make for a more pleasant user experience.
         :type user_visible_data_format: str
-        :return: The order response.
-        :rtype: dict
+        :return: The order response parsed as a dict.
+        :rtype: PhoneAuthenticateResponse
         :raises BankIDError: raises a subclass of this error
                              when error has been returned from server.
 
@@ -155,7 +164,7 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
         requirement: Union[Dict[str, Any], None] = None,
         user_non_visible_data: Union[str, None] = None,
         user_visible_data_format: Union[str, None] = None,
-    ) -> Dict[str, str]:
+    ) -> SignResponse:
         """Request a signing order. The :py:meth:`collect` method
         is used to query the status of the order.
 
@@ -183,8 +192,8 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
             this parameter indicates that userVisibleData holds formatting characters which
             potentially make for a more pleasant user experience.
         :type user_visible_data_format: str
-        :return: The order response.
-        :rtype: dict
+        :return: The order response parsed as a dict.
+        :rtype: SignResponse
         :raises BankIDError: raises a subclass of this error
                      when error has been returned from server.
 
@@ -212,7 +221,7 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
         requirement: Union[Dict[str, Any], None] = None,
         user_non_visible_data: Union[str, None] = None,
         user_visible_data_format: Union[str, None] = None,
-    ) -> Dict[str, str]:
+    ) -> PhoneSignResponse:
         """Initiates an authentication order when the user is talking to
         the RP over the phone. The :py:meth:`collect` method
         is used to query the status of the order.
@@ -242,8 +251,8 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
             this parameter indicates that userVisibleData holds formatting characters which
             potentially make for a more pleasant user experience.
         :type user_visible_data_format: str
-        :return: The order response.
-        :rtype: dict
+        :return: The order response parsed as a dict.
+        :rtype: PhoneSignResponse
         :raises BankIDError: raises a subclass of this error
                      when error has been returned from server.
 
@@ -267,7 +276,7 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
         else:
             raise get_json_error_class(response)
 
-    async def collect(self, order_ref: str) -> dict:
+    async def collect(self, order_ref: str) -> Union[CollectPendingResponse, CollectCompleteResponse, CollectFailedResponse]:
         """Collects the result of a sign or auth order using the
         ``orderRef`` as reference.
 
@@ -326,8 +335,8 @@ class BankIDAsyncClient(BankIDClientBaseclass[httpx.AsyncClient]):
 
         :param order_ref: The ``orderRef`` UUID returned from auth or sign.
         :type order_ref: str
-        :return: The CollectResponse parsed to a dictionary.
-        :rtype: dict
+        :return: The order response parsed to a dict.
+        :rtype: Union[CollectPendingResponse, CollectCompleteResponse, CollectFailedResponse]
         :raises BankIDError: raises a subclass of this error
                              when error has been returned from server.
 

--- a/bankid/baseclient.py
+++ b/bankid/baseclient.py
@@ -1,7 +1,7 @@
 import base64
 import ssl
 from datetime import datetime
-from typing import Tuple, Dict, Any, Union, TypeVar, Generic
+from typing import Any, Dict, Generic, Tuple, TypeVar, Union
 from urllib.parse import urljoin
 
 from bankid.qr import generate_qr_code_content

--- a/bankid/responses.py
+++ b/bankid/responses.py
@@ -1,0 +1,67 @@
+from typing_extensions import Literal, NotRequired, TypedDict
+
+class SignResponse(TypedDict):
+    orderRef: str
+    autoStartToken: str
+    qrStartToken: str
+    qrStartSecret: str
+
+
+class PhoneSignResponse(TypedDict):
+    orderRef: str
+
+
+class AuthenticateResponse(TypedDict):
+    orderRef: str
+    autoStartToken: str
+    qrStartToken: str
+    qrStartSecret: str
+
+
+class PhoneAuthenticateResponse(TypedDict):
+    orderRef: str
+
+
+class Device(TypedDict):
+    ipAddress: str
+    uhi: str
+
+
+class StepUp(TypedDict):
+    mrtd: bool
+
+
+class User(TypedDict):
+    personalNumber: str
+    name: str
+    givenName: str
+    surname: str
+
+
+class CompletionData(TypedDict):
+    user: User
+    device: Device
+    stepUp: StepUp
+    bankIdIssueDate: str
+    signature: str
+    ocspResponse: str
+    risk: NotRequired[str]
+
+
+class _CollectResponse(TypedDict):
+    orderRef: str
+
+
+class CollectPendingResponse(_CollectResponse):
+    status: Literal["pending"]
+    hintCode: str
+
+
+class CollectCompleteResponse(_CollectResponse):
+    status: Literal["complete"]
+    completionData: CompletionData
+
+
+class CollectFailedResponse(_CollectResponse):
+    status: Literal["failed"]
+    hintCode: str

--- a/bankid/syncclient.py
+++ b/bankid/syncclient.py
@@ -4,6 +4,15 @@ import httpx
 
 from bankid.baseclient import BankIDClientBaseclass
 from bankid.exceptions import get_json_error_class
+from bankid.responses import (
+    AuthenticateResponse,
+    CollectCompleteResponse,
+    CollectFailedResponse,
+    CollectPendingResponse,
+    PhoneAuthenticateResponse,
+    PhoneSignResponse,
+    SignResponse,
+)
 
 
 class BankIDClient(BankIDClientBaseclass[httpx.Client]):
@@ -32,7 +41,7 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
         user_visible_data: Union[str, None] = None,
         user_non_visible_data: Union[str, None] = None,
         user_visible_data_format: Union[str, None] = None,
-    ) -> Dict[str, str]:
+    ) -> AuthenticateResponse:
         """Request an authentication order. The :py:meth:`collect` method
         is used to query the status of the order.
 
@@ -62,8 +71,8 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
             this parameter indicates that userVisibleData holds formatting characters which
             potentially make for a more pleasant user experience.
         :type user_visible_data_format: str
-        :return: The order response.
-        :rtype: dict
+        :return: The order response parsed to a dict.
+        :rtype: AuthenticateResponse
         :raises BankIDError: raises a subclass of this error
                              when error has been returned from server.
 
@@ -91,7 +100,7 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
         user_visible_data: Union[str, None] = None,
         user_non_visible_data: Union[str, None] = None,
         user_visible_data_format: Union[str, None] = None,
-    ) -> Dict[str, str]:
+    ) -> PhoneAuthenticateResponse:
         """Initiates an authentication order when the user is talking
         to the RP over the phone. The :py:meth:`collect` method
         is used to query the status of the order.
@@ -123,8 +132,8 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
             this parameter indicates that userVisibleData holds formatting characters which
             potentially make for a more pleasant user experience.
         :type user_visible_data_format: str
-        :return: The order response.
-        :rtype: dict
+        :return: The order response parsed to a dict.
+        :rtype: PhoneAuthenticateResponse
         :raises BankIDError: raises a subclass of this error
                              when error has been returned from server.
 
@@ -155,7 +164,7 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
         requirement: Union[Dict[str, Any], None] = None,
         user_non_visible_data: Union[str, None] = None,
         user_visible_data_format: Union[str, None] = None,
-    ) -> Dict[str, str]:
+    ) -> SignResponse:
         """Request a signing order. The :py:meth:`collect` method
         is used to query the status of the order.
 
@@ -183,8 +192,8 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
             this parameter indicates that userVisibleData holds formatting characters which
             potentially make for a more pleasant user experience.
         :type user_visible_data_format: str
-        :return: The order response.
-        :rtype: dict
+        :return: The order response parsed to a dict.
+        :rtype: SignResponse
         :raises BankIDError: raises a subclass of this error
                      when error has been returned from server.
 
@@ -211,7 +220,7 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
         requirement: Union[Dict[str, Any], None] = None,
         user_non_visible_data: Union[str, None] = None,
         user_visible_data_format: Union[str, None] = None,
-    ) -> Dict[str, str]:
+    ) -> PhoneSignResponse:
         """Initiates an authentication order when the user is talking to
         the RP over the phone.  The :py:meth:`collect` method
         is used to query the status of the order.
@@ -241,8 +250,8 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
             this parameter indicates that userVisibleData holds formatting characters which
             potentially make for a more pleasant user experience.
         :type user_visible_data_format: str
-        :return: The order response.
-        :rtype: dict
+        :return: The order response parsed to a dict.
+        :rtype: PhoneSignResponse
         :raises BankIDError: raises a subclass of this error
                      when error has been returned from server.
 
@@ -266,7 +275,7 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
         else:
             raise get_json_error_class(response)
 
-    def collect(self, order_ref: str) -> dict:
+    def collect(self, order_ref: str) -> Union[CollectPendingResponse, CollectCompleteResponse, CollectFailedResponse]:
         """Collects the result of a sign or auth order using the
         ``orderRef`` as reference.
 
@@ -325,8 +334,8 @@ class BankIDClient(BankIDClientBaseclass[httpx.Client]):
 
         :param order_ref: The ``orderRef`` UUID returned from auth or sign.
         :type order_ref: str
-        :return: The CollectResponse parsed to a dictionary.
-        :rtype: dict
+        :return: The order response parsed to a dict.
+        :rtype: Union[CollectPendingResponse, CollectCompleteResponse, CollectFailedResponse]
         :raises BankIDError: raises a subclass of this error
                              when error has been returned from server.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal=1
+
+[tool:pytest]
+asyncio_default_fixture_loop_scope = session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def ip_address() -> str:
     return "127.0.0.1"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def cert_and_key() -> Tuple[str, str]:
     cert, key = get_test_cert_and_key()
     return str(cert), str(key)


### PR DESCRIPTION
I think this is a neat addition and it shouldn't break anything. I briefly considered validating the response data using pydantic too but I don't think it adds much value in the end.

The last two commits that has to do with the tests are unrelated to the rest but showed up in the pipelines in the PR, thus addressing them here.